### PR TITLE
feat(settings,ui) : PR4: 키 리매핑 화면 추가 + SettingsScreen 마감 & NEXT 프리뷰 유동화

### DIFF
--- a/app/src/main/java/se/tetris/team3/core/Settings.java
+++ b/app/src/main/java/se/tetris/team3/core/Settings.java
@@ -57,7 +57,7 @@ public class Settings {
         keymap.put(Action.EXIT, KeyEvent.VK_ESCAPE);
     }
 
-     /*
+    /*
 
     게임 껐을때도 색맹모드 상태 저장하고 싶다면 이 부분 추가하면 됨
 

--- a/app/src/main/java/se/tetris/team3/ui/GameScreen.java
+++ b/app/src/main/java/se/tetris/team3/ui/GameScreen.java
@@ -175,32 +175,33 @@ public class GameScreen implements Screen {
     }
 
     @Override
-    public void onKeyPressed(KeyEvent e) {
-        Block cur = manager.getCurrentBlock();
-        int[][] shape = (cur != null ? cur.getShape() : null);
+        public void onKeyPressed(KeyEvent e) {
+            Block cur = manager.getCurrentBlock();
+            int[][] shape = (cur != null ? cur.getShape() : null);
 
-        if (manager.isGameOver()) {
-            if(new ScoreManager().isHighScore(manager.getScore()))
-            app.showScreen(new NameInputScreen(app,manager.getScore()));
-            return;
-        }
+            if (manager.isGameOver()) {
+                if(new se.tetris.team3.ui.score.ScoreManager().isHighScore(manager.getScore())) {
+                    app.showScreen(new NameInputScreen(app, manager.getScore()));
+                }
+                return;
+            }
 
-        switch (e.getKeyCode()) {
-            case KeyEvent.VK_LEFT -> {
+            final var km = settings.getKeymap();
+            int code = e.getKeyCode();
+
+            if (code == km.get(se.tetris.team3.core.Settings.Action.MOVE_LEFT)) {
                 if (shape != null) {
                     int nx = manager.getBlockX() - 1;
                     int ny = manager.getBlockY();
                     if (fitsRegion(nx, ny, shape)) manager.tryMove(nx, ny);
                 }
-            }
-            case KeyEvent.VK_RIGHT -> {
+            } else if (code == km.get(se.tetris.team3.core.Settings.Action.MOVE_RIGHT)) {
                 if (shape != null) {
                     int nx = manager.getBlockX() + 1;
                     int ny = manager.getBlockY();
                     if (fitsRegion(nx, ny, shape)) manager.tryMove(nx, ny);
                 }
-            }
-            case KeyEvent.VK_UP -> {
+            } else if (code == km.get(se.tetris.team3.core.Settings.Action.ROTATE)) {
                 if (shape != null) {
                     int sh = shape.length, sw = shape[0].length;
                     int[][] rotated = new int[sw][sh];
@@ -220,17 +221,19 @@ public class GameScreen implements Screen {
                         }
                     }
                 }
-            }
-            case KeyEvent.VK_DOWN -> {
+            } else if (code == km.get(se.tetris.team3.core.Settings.Action.SOFT_DROP)) {
                 if (shape != null) {
                     int nx = manager.getBlockX();
                     int ny = manager.getBlockY() + 1;
                     if (fitsRegion(nx, ny, shape)) manager.tryMove(nx, ny);
-                    else manager.tryMove(nx, ny);
+                    else manager.tryMove(nx, ny); // 기존 로직 유지
                 }
+            } else if (code == km.get(se.tetris.team3.core.Settings.Action.PAUSE)) {
+                // TODO: 일시정지 구현 시 분기
+            } else if (code == km.get(se.tetris.team3.core.Settings.Action.EXIT)) {
+                app.showScreen(new MenuScreen(app));
             }
-            case KeyEvent.VK_ESCAPE -> app.showScreen(new MenuScreen(app));
+
+            app.repaint();
         }
-        app.repaint();
-    }
 }

--- a/app/src/main/java/se/tetris/team3/ui/KeymapScreen.java
+++ b/app/src/main/java/se/tetris/team3/ui/KeymapScreen.java
@@ -1,0 +1,113 @@
+package se.tetris.team3.ui;
+
+import se.tetris.team3.core.Settings;
+import se.tetris.team3.core.Settings.Action;
+import se.tetris.team3.store.SettingsStore;
+
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class KeymapScreen implements Screen {
+
+    private final AppFrame app;
+    private final Settings settings;
+
+    private final List<Action> items = new ArrayList<>();
+    private int cursor = 0;
+    private boolean waitingInput = false;
+    private String status = "↑/↓: 이동  Enter: 입력대기  ESC/Backspace: 뒤로가기";
+
+    public KeymapScreen(AppFrame app) {
+        this.app = app;
+        this.settings = app.getSettings();
+        items.add(Action.MOVE_LEFT);
+        items.add(Action.MOVE_RIGHT);
+        items.add(Action.ROTATE);
+        items.add(Action.SOFT_DROP);
+        items.add(Action.PAUSE);
+        items.add(Action.EXIT);
+    }
+
+    @Override public void render(Graphics2D g2) {
+        int w = app.getWidth(), h = app.getHeight();
+        g2.setColor(Color.BLACK);
+        g2.fillRect(0,0,w,h);
+
+        g2.setColor(Color.WHITE);
+        g2.setFont(new Font("SansSerif", Font.BOLD, 28));
+        g2.drawString("키 설정", 36, 60);
+
+        g2.setFont(new Font("SansSerif", Font.PLAIN, 18));
+        int y = 110;
+        for (int i = 0; i < items.size(); i++) {
+            Action a = items.get(i);
+            String left = a.name();
+            String right = KeyEvent.getKeyText(settings.getKeymap().get(a));
+            if (i == cursor) {
+                g2.setColor(new Color(30,144,255));
+                g2.fillRoundRect(26, y-18, w-52, 28, 8, 8);
+                g2.setColor(Color.WHITE);
+            } else {
+                g2.setColor(Color.LIGHT_GRAY);
+            }
+            g2.drawString(left, 46, y);
+
+            String disp = (waitingInput && i==cursor) ? "입력 대기..." : right;
+            int strW = g2.getFontMetrics().stringWidth(disp);
+            g2.drawString(disp, w - 46 - strW, y);
+            y += 36;
+        }
+
+        g2.setColor(waitingInput ? Color.ORANGE : Color.GRAY);
+        g2.setFont(new Font("SansSerif", Font.PLAIN, 16));
+        g2.drawString(status, 36, h - 36);
+    }
+
+    private boolean isKeyInUse(int keyCode, Action except) {
+        for (Map.Entry<Action, Integer> e : settings.getKeymap().entrySet()) {
+            if (e.getKey() != except && e.getValue() == keyCode) return true;
+        }
+        return false;
+    }
+
+    @Override public void onKeyPressed(KeyEvent e) {
+        int code = e.getKeyCode();
+
+        if (waitingInput) {
+            // 취소
+            if (code == KeyEvent.VK_ESCAPE || code == KeyEvent.VK_BACK_SPACE) {
+                waitingInput = false;
+                status = "입력 취소됨";
+                app.repaint();
+                return;
+            }
+
+            Action target = items.get(cursor);
+            if (isKeyInUse(code, target)) {
+                status = "이미 사용 중: " + KeyEvent.getKeyText(code);
+            } else {
+                settings.getKeymap().put(target, code);
+                SettingsStore.save(settings); // 저장
+                status = target.name() + " → " + KeyEvent.getKeyText(code) + " 저장됨";
+                waitingInput = false;
+            }
+            app.repaint();
+            return;
+        }
+
+        // 일반 네비
+        switch (code) {
+            case KeyEvent.VK_UP -> cursor = (cursor - 1 + items.size()) % items.size();
+            case KeyEvent.VK_DOWN -> cursor = (cursor + 1) % items.size();
+            case KeyEvent.VK_ENTER -> {
+                waitingInput = true;
+                status = items.get(cursor).name() + " : 새 키를 눌러주세요 (ESC/Backspace 취소)";
+            }
+            case KeyEvent.VK_ESCAPE, KeyEvent.VK_BACK_SPACE -> app.showScreen(new SettingsScreen(app));
+        }
+        app.repaint();
+    }
+}

--- a/app/src/main/java/se/tetris/team3/ui/SettingsScreen.java
+++ b/app/src/main/java/se/tetris/team3/ui/SettingsScreen.java
@@ -11,8 +11,10 @@ public class SettingsScreen implements Screen {
     private final AppFrame app;
     private final Settings settings;
 
+    // ▶ "키 설정" 항목 추가
     private final String[] items = new String[] {
             "화면 크기 프리셋: %s",
+            "키 설정",
             "색맹 모드: %s",
             "스코어 초기화",
             "기본값 복원",
@@ -47,20 +49,24 @@ public class SettingsScreen implements Screen {
                 SettingsStore.save(settings);
                 app.setSize(settings.resolveWindowSize());
             }
-            case 1 -> { // 색맹 모드 토글
+            case 1 -> { // 키 설정 화면으로 이동
+                app.showScreen(new KeymapScreen(app));
+                return;
+            }
+            case 2 -> { // 색맹 모드 토글
                 settings.setColorBlindMode(!settings.isColorBlindMode());
                 SettingsStore.save(settings);
             }
-            case 2 -> { // 스코어 초기화
+            case 3 -> { // 스코어 초기화
                 SettingsStore.resetScores();
                 javax.swing.JOptionPane.showMessageDialog(null, "스코어가 초기화되었습니다.");
             }
-            case 3 -> { // 기본값 복원
+            case 4 -> { // 기본값 복원
                 settings.resetDefaults();
                 SettingsStore.save(settings);
                 app.setSize(settings.resolveWindowSize());
             }
-            case 4 -> app.showScreen(new MenuScreen(app)); // 뒤로가기
+            case 5 -> app.showScreen(new MenuScreen(app)); // 뒤로가기
         }
     }
 
@@ -113,7 +119,7 @@ public class SettingsScreen implements Screen {
     private String formatItem(int i) {
         return switch (i) {
             case 0 -> String.format(items[i], settings.getSizePreset().name());
-            case 1 -> String.format(items[i], settings.isColorBlindMode() ? "ON" : "OFF");
+            case 2 -> String.format(items[i], settings.isColorBlindMode() ? "ON" : "OFF");
             default -> items[i];
         };
     }


### PR DESCRIPTION
## 요약
- PR4: KeymapScreen 추가, SettingsScreen 연동, GameScreen에 커스텀 키 적용
- PR5: SettingsScreen 마감(색맹 모드/스코어 초기화/기본값 복원), NEXT 프리뷰 유동화

## 주요 변경
- ui/KeymapScreen: 키 리매핑(중복 방지, ESC/Backspace 취소, 즉시 저장)
- ui/SettingsScreen: '키 설정' 메뉴 추가 및 각 항목 동작 완성
- ui/GameScreen: 입력 처리에 settings.getKeymap() 적용
- ui/GameManager: NEXT 프리뷰 레이아웃을 프리셋/shape 기반으로 스케일링
- store/SettingsStore: 설정 저장/로드, resetScores 연동

## 테스트
- 키 설정: 항목 이동→입력 대기→새 키 저장→게임에서 즉시 반영
- 색맹 모드 ON/OFF: 필드/프리뷰 패턴 적용 확인
- 스코어 초기화: Scoreboard 비워짐 확인
- 기본값 복원: 프리셋/키맵/색맹 모드 원복
- 재실행 후 설정 유지(settings.properties)

