### PR TITLE
feat: 모든 아이템 타입 화면 표시 및 파괴 시 효과 실행 시스템 구현

### DIFF
--- a/app/src/main/java/se/tetris/team3/blocks/Block.java
+++ b/app/src/main/java/se/tetris/team3/blocks/Block.java
@@ -35,8 +35,8 @@ public abstract class Block {
         }
         shape = rotated;
 
-        // L이 붙어 있으면 좌표를 같이 회전 (r,c) -> (c, rows-1-r)
-        if (itemType == 'L' && itemRow >= 0 && itemCol >= 0) {
+        // 아이템이 붙어 있으면 좌표를 같이 회전 (r,c) -> (c, rows-1-r)
+        if (itemType != 0 && itemRow >= 0 && itemCol >= 0) {
             int newRow = itemCol;
             int newCol = rows - 1 - itemRow; // 주의: rows는 "회전 전" 높이
             itemRow = newRow;

--- a/app/src/main/java/se/tetris/team3/ui/GameScreen.java
+++ b/app/src/main/java/se/tetris/team3/ui/GameScreen.java
@@ -166,6 +166,12 @@ public class GameScreen implements Screen {
                     int x = padding + c * blockSize;
                     int y = padding + r * blockSize;
                     PatternPainter.drawCell(g2, x, y, blockSize, Color.GRAY, null, settings.isColorBlindMode());
+                    
+                    // 고정된 블록에 아이템이 있으면 글자 표시
+                    if (manager.hasItem(r, c)) {
+                        char itemType = manager.getItemType(r, c);
+                        drawCenteredChar(g2, x, y, blockSize, itemType);
+                    }
                 }
             }
         }
@@ -180,7 +186,7 @@ public class GameScreen implements Screen {
 
                 // L 위치 (있을 때만 사용)
                 Integer ir = null, ic = null;
-                if (cur.getItemType() == 'L') {
+                if (cur.getItemType() != 0) {
                     try {
                         ir = (Integer) cur.getClass().getMethod("getItemRow").invoke(cur);
                         ic = (Integer) cur.getClass().getMethod("getItemCol").invoke(cur);
@@ -197,8 +203,8 @@ public class GameScreen implements Screen {
                                 PatternPainter.drawCell(g2, x, y, blockSize, base, cur, settings.isColorBlindMode());
 
                                 // ★ 줄삭제 L은 붙은 칸에만 문자 오버레이(무게추는 글자 없음)
-                                if (cur.getItemType() == 'L' && ir != null && ic != null && r == ir && c == ic) {
-                                    drawCenteredChar(g2, x, y, blockSize, 'L');
+                                if (cur.getItemType() != 0 && ir != null && ic != null && r == ir && c == ic) {
+                                    drawCenteredChar(g2, x, y, blockSize, cur.getItemType());
                                 }
                             }
                         }


### PR DESCRIPTION
    - 현재 블록과 고정된 블록에서 L뿐만 아니라 T 등 모든 아이템 타입 표시
    - 블록 고정 후에도 회색 배경 위에 아이템 글자 유지되도록 수정
    - 라인 클리어 및 무게추 파괴 시 T 아이템 감지하여 효과 실행
    - 아이템 정보 저장을 위한 itemField 배열 추가
    - 파티클 효과와 아이템 시스템 통합